### PR TITLE
Added docs about selector types

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,15 +175,31 @@ cy.eyesCheckWindow({ tag: 'your tag', sizeMode: 'your size mode' })
   - **`selector`**: Take a screenshot of the content of the element targeted by css or xpath selector. It's necessary to specify the value of the selector in the `selector` argument.
   - **`region`**: Take a screenshot of a region of the page, specified by coordinates. It's necessary to specify the value of the region in the `region` argument.
 
-- `selector` (optional): In case `sizeMode` is `selector`, this should be the actual css selector to an element, and the screenshot would be the content of that element. For example:
+- `selector` (optional): In case `sizeMode` is `selector`, this should be the actual css or xpath selector to an element, and the screenshot would be the content of that element. For example:
 
 ```js
+// Using a css selector
 cy.eyesCheckWindow({
   sizeMode: 'selector',
   selector: {
-    type: 'css', // or 'xpath'
+    type: 'css',
     selector: '.my-element' // or '//button'
   }
+});
+
+// Using an xpath selector
+cy.eyesCheckWindow({
+  sizeMode: 'selector',
+  selector: {
+    type: 'xpath',
+    selector: '//button[1]'
+  }
+});
+
+// The shorthand string version defaults to css selectors
+cy.eyesCheckWindow({
+  sizeMode: 'selector',
+  selector: '.my-element'
 });
 ```
 


### PR DESCRIPTION
There is no input validation in either `eyes-sdk-core` or `visual-grid-client` so it just works.