### PR TITLE
Fixes a spelling mistake during eyes-setup

### DIFF
--- a/src/setup/handleCommands.js
+++ b/src/setup/handleCommands.js
@@ -14,7 +14,7 @@ function handleCommands(cwd) {
 
   if (!isCommandsDefined(commandsFileContent)) {
     writeFileSync(commandsFilePath, addEyesCommands(commandsFileContent));
-    console.log(chalk.cyan('Commnads defined.'));
+    console.log(chalk.cyan('Commands defined.'));
   } else {
     console.log(chalk.cyan('Commands already defined.'));
   }


### PR DESCRIPTION
Fixes a spelling mistake seen when setting up Applitools with Cypress for the first time and running `npx eyes-setup`